### PR TITLE
Add storytelling suit designer website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Dr-Lucas
+
+## Storytelling Suit Designer
+
+This project is a simple website that lets users design a custom suit. The interface features:
+
+- A light cream color scheme.
+- Fabric selection from predefined options.
+- Custom inside lining using uploaded images.
+
+### Running the Site
+
+Open `index.html` in a web browser to start designing your suit.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Storytelling Suit Designer</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Design Your Storytelling Suit</h1>
+  </header>
+  <main>
+    <section id="fabric-selection">
+      <h2>Select Fabric</h2>
+      <div class="fabric-options">
+        <label>
+          <input type="radio" name="fabric" value="wool" checked />
+          <img src="https://via.placeholder.com/100?text=Wool" alt="Wool Fabric" />
+          Wool
+        </label>
+        <label>
+          <input type="radio" name="fabric" value="cotton" />
+          <img src="https://via.placeholder.com/100?text=Cotton" alt="Cotton Fabric" />
+          Cotton
+        </label>
+        <label>
+          <input type="radio" name="fabric" value="silk" />
+          <img src="https://via.placeholder.com/100?text=Silk" alt="Silk Fabric" />
+          Silk
+        </label>
+      </div>
+    </section>
+
+    <section id="lining-design">
+      <h2>Design Your Lining</h2>
+      <p>Select an image to use as your custom lining.</p>
+      <input type="file" id="lining-input" accept="image/*" />
+      <div id="lining-preview"></div>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const liningInput = document.getElementById('lining-input');
+  const liningPreview = document.getElementById('lining-preview');
+
+  liningInput.addEventListener('change', () => {
+    const file = liningInput.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+      liningPreview.innerHTML = `<img src="${e.target.result}" alt="Lining preview" />`;
+    };
+    reader.readAsDataURL(file);
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,37 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f5dc; /* light cream */
+  margin: 0;
+  padding: 0;
+  color: #333;
+}
+
+header {
+  text-align: center;
+  padding: 1rem;
+  background-color: #fff8dc;
+}
+
+main {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background-color: #ffffffcc;
+  border-radius: 8px;
+}
+
+.fabric-options {
+  display: flex;
+  gap: 1rem;
+}
+
+.fabric-options label {
+  text-align: center;
+}
+
+#lining-preview img {
+  margin-top: 1rem;
+  max-width: 100%;
+  border: 2px solid #ccc;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- build light-cream themed webpage for designing custom suits
- allow fabric selection from preset options
- enable lining customization via uploaded images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b65ed2ceec832e9b90fdb4eda38181